### PR TITLE
bugfix

### DIFF
--- a/joyrpc-core/src/main/java/io/joyrpc/util/ClassUtils.java
+++ b/joyrpc-core/src/main/java/io/joyrpc/util/ClassUtils.java
@@ -350,7 +350,6 @@ public class ClassUtils {
             if (loader != null) {
                 return loader;
             }
-            return clazz.getClassLoader();
         }
         return ClassLoader.getSystemClassLoader();
     }


### PR DESCRIPTION
loader = clazz.getClassLoader();
            if (loader != null) {
                return loader;
            }
            return clazz.getClassLoader();
会一直return null值.